### PR TITLE
feat: ignore html tags that contain only special characters

### DIFF
--- a/src/Validator.test.ts
+++ b/src/Validator.test.ts
@@ -35,6 +35,11 @@ describe('Validator', () => {
             },
         },
         {
+            name: 'Ignores html special characters',
+            html: '<span> &nbsp;&quot; </span>',
+            result: true,
+        },
+        {
             name: 'Reports nested i18n tags',
             html: '<span i18n="Greeting:Hello user">Hello <span i18n="Text:User">User!</span></span>',
             result: {


### PR DESCRIPTION
#### PR checklist

- [x] Ran `npm run lint` and `npm run test`
- [x] Added tests if applicable

#### What changes did you make?

Title ^ noticed @mmpowers-mi was running into this sometimes in his latest PR, so made changes so ignores won't be necessary any more. Changes the options a little bit so this should be a major revision (though for our usage is not breaking)